### PR TITLE
Connection tests

### DIFF
--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -34,7 +34,7 @@ defmodule Cassandrax.Connection do
     do: ["SELECT ", intersperse_map(fields, ", ", &quote_name(&1))]
 
   defp select(%{distinct: fields}) when is_list(fields),
-    do: ["SELECT DISTINCT(", intersperse_map(fields, ", ", &quote_name(&1))]
+    do: ["SELECT DISTINCT(", intersperse_map(fields, ", ", &quote_name(&1)), ?)]
 
   defp from(%{from: table}, keyspace), do: [" FROM ", quote_table(keyspace, table)]
 

--- a/lib/cassandrax/query/builder.ex
+++ b/lib/cassandrax/query/builder.ex
@@ -23,6 +23,7 @@ defmodule Cassandrax.Query.Builder do
     end
   end
 
+  # TODO fix DSL so contains and contains_key work without having to define a custom where function
   @allowed_operators [
     :==,
     :!=,
@@ -30,9 +31,9 @@ defmodule Cassandrax.Query.Builder do
     :<,
     :>=,
     :<=,
-    :in,
-    :contains,
-    :contains_key
+    :in
+    # :contains,
+    # :contains_key
   ]
 
   def build_fragment(:where, {operator, _, [field, value]}) when operator in @allowed_operators,

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -1,0 +1,63 @@
+defmodule Cassandrax.ConnectionTest do
+  use Cassandrax.DataCase
+
+  describe "child_spec/1" do
+    assert %{start: {Xandra.Cluster, :start_link, ["options"]}} =
+             Cassandrax.Connection.child_spec("options")
+  end
+
+  defmodule TestKeyspace do
+    use Cassandrax.Keyspace, cluster: Cassandrax.TestConn, name: "test_keyspace"
+  end
+
+  defmodule TestSchema do
+    use Cassandrax.Schema
+    import Ecto.Changeset
+
+    @primary_key [:id, :order_id]
+
+    table "my_table" do
+      field(:id, :string)
+      field(:order_id, :integer)
+      field(:set, MapSetType)
+      field(:list, {:array, :string})
+      field(:map, :map)
+    end
+
+    def change(%TestSchema{} = struct, attrs) do
+      struct
+      |> cast(attrs, [
+        :id,
+        :order_id,
+        :set,
+        :list,
+        :map
+      ])
+    end
+  end
+
+  import Kernel, except: [to_string: 1]
+  defp to_string({iodata, _values}), do: IO.iodata_to_binary(iodata)
+
+  describe "all/2" do
+    import Cassandrax.Query
+
+    test "defined fields to be selected" do
+      queryable = TestSchema |> select([:id, :order_id, :map])
+      statement = Cassandrax.Connection.all(TestKeyspace, queryable) |> to_string()
+      assert statement =~ ~r/SELECT "id", "order_id", "map" FROM "test_keyspace"."my_table"/
+    end
+
+    test "defined where clauses" do
+      queryable = TestSchema |> where(:id == "abc123") |> where(:order_id < 100)
+      statement = Cassandrax.Connection.all(TestKeyspace, queryable) |> to_string()
+      assert statement =~ ~r/WHERE \("order_id" < \?\) AND \("id" = \?\)/
+    end
+
+    test "defined distinct fields" do
+      queryable = TestSchema |> distinct([:id, :order_id])
+      statement = Cassandrax.Connection.all(TestKeyspace, queryable) |> to_string()
+      assert statement =~ ~r/SELECT DISTINCT\("id", "order_id"\)/
+    end
+  end
+end

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -1,3 +1,5 @@
+Code.require_file("../support/data_case.exs", __DIR__)
+
 defmodule Cassandrax.ConnectionTest do
   use Cassandrax.DataCase
 

--- a/test/support/data_case.exs
+++ b/test/support/data_case.exs
@@ -6,8 +6,6 @@ defmodule Cassandrax.DataCase do
   alias Cassandrax.TestConn
 
   using do
-    import Cassandrax.Query
-
     quote do
       setup_all do
         start_test_connection()


### PR DESCRIPTION
Changes:
- 
- Fixed closing parenthesis on `DISTINCT`
- Added tests for supported operators [1]
- Commented out `contains` and `contains_key` operators as they're not currently working [2]

Observations
-
[1] Tests only assert the generated statement is correct, we're still missing complete tests that also assert the order of values are correctly returned

[2] The current problem with using `where(:field contains value)` is that the `contains` keyword doesn't exist. We have two options to fix that:
[2.a] Create two extra functions `contains/2` and `contains_key/2` analogous to `where/2`, which could be used such as:
```
Schema |> contains(list_field: value)
```
[2.b] Add the binding notation, like [Ecto](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query/builder/filter.ex) does, and change the DSL like so:
```
Schema |> where(s, s.list_field contains another_value)
```
While the current implementation raises a SyntaxError with the message `syntax error before: contains`, the above suggestion generates a valid AST which can be resolved in Cassandrax.Query.Builder, as follows :
```
{:where, [],
 [
   {:__aliases__, [alias: false], [:Schema]},
   {:s, [], Elixir},
   {{:., [], [{:s, [], Elixir}, :list_field]}, [],
    [{:contains, [], [{:value, [], Elixir}]}]}
 ]}
```