### PR TITLE
Invalid cql

### DIFF
--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -66,7 +66,7 @@ defmodule Cassandrax.Connection do
   defp group_by(%{group_bys: []}), do: []
 
   defp group_by(%{group_bys: group_bys}) when is_list(group_bys) do
-    [" GROUP BY (", intersperse_map(group_bys, ", ", &quote_name(&1)), ?)]
+    [" GROUP BY ", intersperse_map(group_bys, ", ", &quote_name(&1))]
   end
 
   defp order_by(%{order_bys: []}), do: []

--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -34,7 +34,7 @@ defmodule Cassandrax.Connection do
     do: ["SELECT ", intersperse_map(fields, ", ", &quote_name(&1))]
 
   defp select(%{distinct: fields}) when is_list(fields),
-    do: ["SELECT DISTINCT(", intersperse_map(fields, ", ", &quote_name(&1)), ?)]
+    do: ["SELECT DISTINCT ", intersperse_map(fields, ", ", &quote_name(&1))]
 
   defp from(%{from: table}, keyspace), do: [" FROM ", quote_table(keyspace, table)]
 

--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -72,7 +72,7 @@ defmodule Cassandrax.Connection do
   defp order_by(%{order_bys: []}), do: []
 
   defp order_by(%{order_bys: order_bys}) when is_list(order_bys) do
-    [" ORDER BY (", intersperse_map(order_bys, ", ", &quote_name(&1)), ?)]
+    [" ORDER BY ", intersperse_map(order_bys, ", ", &quote_name(&1))]
   end
 
   defp per_partition_limit(%{per_partition_limit: nil}), do: {[], []}

--- a/lib/cassandrax/keyspace/schema.ex
+++ b/lib/cassandrax/keyspace/schema.ex
@@ -239,6 +239,7 @@ defmodule Cassandrax.Keyspace.Schema do
     do: %{struct | __meta__: %{meta | state: state}}
 
   defp type_check(_, []), do: {:ok, []}
+
   defp type_check(schema, [{field, value} | remaining_changes]) do
     type = schema.__schema__(:type, field)
 
@@ -248,6 +249,7 @@ defmodule Cassandrax.Keyspace.Schema do
           {:ok, rest} -> {:ok, [value | rest]}
           other -> other
         end
+
       :error ->
         {:error,
          %Ecto.ChangeError{

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -59,7 +59,7 @@ defmodule Cassandrax.ConnectionTest do
 
     test "defined group by clause" do
       queryable = TestSchema |> group_by([:order_id, :field])
-      assert all(queryable) =~ ~r/GROUP BY \("order_id", "field"\)/
+      assert all(queryable) =~ ~r/GROUP BY "order_id", "field"/
     end
 
     test "defined order by clause" do

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -54,7 +54,7 @@ defmodule Cassandrax.ConnectionTest do
 
     test "defined distinct fields" do
       queryable = TestSchema |> distinct([:id, :order_id])
-      assert all(queryable) =~ ~r/SELECT DISTINCT\("id", "order_id"\)/
+      assert all(queryable) =~ ~r/SELECT DISTINCT "id", "order_id"/
     end
 
     test "defined group by clause" do
@@ -64,7 +64,7 @@ defmodule Cassandrax.ConnectionTest do
 
     test "defined order by clause" do
       queryable = TestSchema |> order_by([:order_id])
-      assert all(queryable) =~ ~r/ORDER BY \("order_id"\)/
+      assert all(queryable) =~ ~r/ORDER BY "order_id"/
     end
 
     test "defined per partition limit clause" do


### PR DESCRIPTION
## Problem

- Order by, distinct and group by queries were generating invalid CQL due to extra parenthesis.

## Solution

- Removed the parenthesis and created tests. 