### PR TITLE
Allow passing variables to where

### DIFF
--- a/lib/cassandrax/query/builder.ex
+++ b/lib/cassandrax/query/builder.ex
@@ -14,6 +14,14 @@ defmodule Cassandrax.Query.Builder do
     end
   end
 
+  def build(type, queryable, [{_, value}] = expression) when is_tuple(value) do
+    quote do
+      fragment = Cassandrax.Query.Builder.build_fragment(unquote(type), unquote(expression))
+      query = Cassandrax.Queryable.to_query(unquote(queryable))
+      Cassandrax.Query.Builder.add_fragment(unquote(type), fragment, query)
+    end
+  end
+
   def build(type, queryable, value) do
     fragment = build_fragment(type, value)
 

--- a/lib/cassandrax/query/builder.ex
+++ b/lib/cassandrax/query/builder.ex
@@ -16,8 +16,8 @@ defmodule Cassandrax.Query.Builder do
 
   def build(type, queryable, [{_, value}] = expression) when is_tuple(value) do
     quote do
-      fragment = Cassandrax.Query.Builder.build_fragment(unquote(type), unquote(expression))
       query = Cassandrax.Queryable.to_query(unquote(queryable))
+      fragment = Cassandrax.Query.Builder.build_fragment(unquote(type), unquote(expression))
       Cassandrax.Query.Builder.add_fragment(unquote(type), fragment, query)
     end
   end

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -108,6 +108,14 @@ defmodule Cassandrax.ConnectionTest do
       assert all(queryable) =~ ~r/WHERE \("id" IN \?\)/
     end
 
+    test "defined keyword where clause with multipe values as variables" do
+      id = 1
+      order_id = 2
+      queryable = TestSchema |> where(id: id) |> where(order_id: order_id)
+
+      assert all(queryable) =~ ~r/WHERE \("order_id" = \?\) AND \("id" = \?\)/
+    end
+
     @tag :pending
     test "defined where clause with contains operators" do
       # queryable = TestSchema |> where(:list contains "abc123") |> where(:map contains_key "def456")

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -102,6 +102,12 @@ defmodule Cassandrax.ConnectionTest do
       assert all(queryable) =~ ~r/WHERE \("id" IN \?\)/
     end
 
+    test "defined keyword where clause with list as variable" do
+      list = ["abc123", "def456"]
+      queryable = TestSchema |> where(id: list)
+      assert all(queryable) =~ ~r/WHERE \("id" IN \?\)/
+    end
+
     @tag :pending
     test "defined where clause with contains operators" do
       # queryable = TestSchema |> where(:list contains "abc123") |> where(:map contains_key "def456")


### PR DESCRIPTION
I'm new to Elixir so I'm not sure if this is the best solution, please let me know.

When passing a list to the build function, it doesn't match the value as a list because it is quoted, i.e. [id: {:list, [line: 107], nil}], causing the query to be wrong:

```ex
     left:  "SELECT * FROM \"test_keyspace\".\"my_table\" WHERE (\"id\" = ?)"
     right: ~r/WHERE \("id" IN \?\)/
```

That produced a regression with multiple where clauses with variables:

```
     left:  "SELECT * FROM \"test_keyspace\".\"my_table\" WHERE (\"id\" = ?) AND (\"id\" = ?)"
     right: ~r/WHERE \("order_id" = \?\) AND \("id" = \?\)/
```

I debugged and `fragment` changes when `Cassandrax.Queryable.to_query(unquote(queryable))` is called, but I don't really understand why.

closes https://github.com/loopsocial/cassandrax/issues/15