### PR TITLE
Adds support for generating truncate table queries.

### DIFF
--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -118,6 +118,8 @@ defmodule Cassandrax.Connection do
     ["DELETE FROM ", quote_table(keyspace, table), " WHERE " | filters]
   end
 
+  def truncate(keyspace, table), do: ["TRUNCATE TABLE ", quote_table(keyspace, table)]
+
   defp assemble_filters(filters) do
     intersperse_map(filters, " AND ", fn field ->
       field = field |> Atom.to_string() |> quote_name()

--- a/lib/cassandrax/keyspace.ex
+++ b/lib/cassandrax/keyspace.ex
@@ -95,6 +95,9 @@ defmodule Cassandrax.Keyspace do
       def delete!(struct, opts \\ []),
         do: Cassandrax.Keyspace.Schema.delete!(__MODULE__, struct, opts)
 
+      def truncate(module_or_table) when is_atom(module_or_table),
+        do: Cassandrax.Keyspace.Schema.truncate(__MODULE__, module_or_table)
+
       ## Queryable
 
       def all(queryable, opts \\ []),
@@ -255,6 +258,16 @@ defmodule Cassandrax.Keyspace do
               struct_or_changeset :: Ecto.Schema.t() | Ecto.Changeset.t(),
               opts :: Keyword.t()
             ) :: Cassandrax.Schema.t()
+
+  @doc """
+  Truncates a schema.
+
+  ## Example
+  ```
+  MyKeyspace.truncate(User)
+  ```
+  """
+  @callback truncate(module() | atom()) :: :ok
 
   @doc """
   Fetches all entries from the data store that matches the given query.

--- a/lib/cassandrax/schema.ex
+++ b/lib/cassandrax/schema.ex
@@ -68,6 +68,7 @@ defmodule Cassandrax.Schema do
 
       def __schema__(:queryable), do: %Cassandrax.Query{from: unquote(source), schema: __MODULE__}
       def __schema__(:pk), do: @primary_key
+      def __cassandrax_source__, do: unquote(source)
 
       # Set it to false to bypass Ecto primary_key verification
       @primary_key false

--- a/test/cassandrax/keyspace_test.exs
+++ b/test/cassandrax/keyspace_test.exs
@@ -542,6 +542,48 @@ defmodule Cassandrax.KeyspaceTest do
     end
   end
 
+  describe "truncate" do
+    setup do
+      [
+        first: fixture(TestData, id: "0", timestamp: "00:00", data: "0"),
+        second:
+          fixture(TestData,
+            id: "1",
+            timestamp: "01:00",
+            data: "1",
+            svalue: MapSet.new(["one", "another one"])
+          )
+      ]
+    end
+
+    test "truncates all records on the table when passed module that uses Cassandrax.Schema" do
+      assert Enum.count(TestKeyspace.all(TestData)) == 2
+      assert {:ok, %Xandra.Void{}} = TestKeyspace.truncate(TestData)
+      assert Enum.count(TestKeyspace.all(TestData)) == 0
+    end
+
+    test "truncates all records on the table when passed valid table name" do
+      assert Enum.count(TestKeyspace.all(TestData)) == 2
+      assert {:ok, %Xandra.Void{}} = TestKeyspace.truncate(:test_data)
+      assert Enum.count(TestKeyspace.all(TestData)) == 0
+    end
+
+    test "returns error when passed invalid module" do
+      assert {:error, "module Elixir.String does not use Cassandrax.Schema"} =
+               TestKeyspace.truncate(String)
+    end
+
+    test "returns error when passed invalid table name" do
+      assert {:error,
+              %Xandra.Error{
+                __exception__: true,
+                message: "table test_data2 does not exist",
+                reason: :invalid,
+                warnings: []
+              }} = TestKeyspace.truncate(:test_data2)
+    end
+  end
+
   describe "cql" do
     setup do
       [


### PR DESCRIPTION
Add truncate function for generating TRUNCATE TABLE $table_name queries 

This in particular is useful for a simple way to cleanup test records generated during tests. 