### PR TITLE
Support specifying asc or desc sort order in order_by clauses.

### DIFF
--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -70,7 +70,7 @@ defmodule Cassandrax.Connection do
   defp order_by(%{order_bys: []}), do: []
 
   defp order_by(%{order_bys: order_bys}) when is_list(order_bys) do
-    [" ORDER BY ", intersperse_map(order_bys, ", ", &quote_name(&1))]
+    [" ORDER BY ", intersperse_map(order_bys, ", ", &quote_order_name(&1))]
   end
 
   defp per_partition_limit(%{per_partition_limit: nil}), do: {[], []}
@@ -145,6 +145,11 @@ defmodule Cassandrax.Connection do
 
   defp quote_name(atom) when is_atom(atom), do: quote_name(Atom.to_string(atom))
   defp quote_name(string) when is_binary(string), do: [?", string, ?"]
+
+  defp quote_order_name({name, sort_order}),
+    do: [quote_name(name), " ", String.upcase(to_string(sort_order))]
+
+  defp quote_order_name(name), do: quote_name(name)
 
   defp quote_table(keyspace, table), do: [quote_name(keyspace), ?., quote_name(table)]
 

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -65,6 +65,16 @@ defmodule Cassandrax.ConnectionTest do
       assert all(queryable) =~ ~r/ORDER BY "order_id"/
     end
 
+    test "defined order by clause with ASC sort order" do
+      queryable = TestSchema |> order_by(order_id: :asc)
+      assert all(queryable) =~ ~r/ORDER BY "order_id" ASC/
+    end
+
+    test "defined order by clause with DESC sort order" do
+      queryable = TestSchema |> order_by(order_id: :desc)
+      assert all(queryable) =~ ~r/ORDER BY "order_id" DESC/
+    end
+
     test "defined per partition limit clause" do
       queryable = TestSchema |> per_partition_limit(25)
       assert all(queryable) =~ ~r/PER PARTITION LIMIT \?/

--- a/test/cassandrax/keyspace_test.exs
+++ b/test/cassandrax/keyspace_test.exs
@@ -598,6 +598,18 @@ defmodule Cassandrax.KeyspaceTest do
       assert [^first, ^second] = TestKeyspace.all(query)
     end
 
+    test "order by asc", %{first: first, second: second} do
+      query = TestData |> allow_filtering() |> where(id: "0") |> order_by(timestamp: :asc)
+
+      assert [^first, ^second] = TestKeyspace.all(query)
+    end
+
+    test "order by desc", %{first: first, second: second} do
+      query = TestData |> allow_filtering() |> where(id: "0") |> order_by(timestamp: :desc)
+
+      assert [^second, ^first] = TestKeyspace.all(query)
+    end
+
     test "distinct" do
       query = TestData |> allow_filtering() |> distinct([:id])
       assert [%TestData{id: "0"}, %TestData{id: "1"}] = TestKeyspace.all(query)


### PR DESCRIPTION
Allows the sort order, ie asc/desc to be specified when using order_by. 