### PR TITLE
Allow data streaming queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,17 @@ iex(20)> UserById
   |> MyKeyspace.all()
 [%UserById{__meta__: %Ecto.Schema.Metadata{:loaded, "user_by_id"}, id: 3, user_name: "adam", age: 31}}]
 ```
+
+Streaming data is supported.
+
+```elixir
+iex(21)> users = MyKeyspace.stream(UserById, page_size: 20)
+#Function<59.58486609/2 in Stream.transform/3>
+
+iex(22) Emum.to_list(users)
+[
+  %UserById{__meta__: %Ecto.Schema.Metadata{:loaded, "user_by_id"}, id: 1, user_name: "alice"},
+  %UserById{__meta__: %Ecto.Schema.Metadata{:loaded, "user_by_id"}, id: 2, user_name: "eve"},
+  ...
+]
+```

--- a/lib/cassandrax.ex
+++ b/lib/cassandrax.ex
@@ -168,12 +168,18 @@ defmodule Cassandrax do
   end
 
   defp wait_connection(startup) do
+    block_until_connection = Application.get_env(:cassandrax, :block_until_connection, true)
+
     case startup do
       {:ok, _supervisor} ->
-        retries = Application.get_env(:cassandrax, :retries, 10)
-        interval = Application.get_env(:cassandrax, :interval, 100)
-        wait_connection(clusters(), retries, interval)
-        startup
+        if block_until_connection do
+          retries = Application.get_env(:cassandrax, :retries, 10)
+          interval = Application.get_env(:cassandrax, :interval, 100)
+          wait_connection(clusters(), retries, interval)
+          startup
+        else
+          startup
+        end
 
       error ->
         error

--- a/lib/cassandrax.ex
+++ b/lib/cassandrax.ex
@@ -204,4 +204,11 @@ defmodule Cassandrax do
       {:error, error} -> {:error, error}
     end
   end
+
+  def stream_cql(conn, statement, values \\ [], opts \\ []) do
+    case Cassandrax.Connection.prepare(conn, statement) do
+      {:ok, prepared} -> Cassandrax.Connection.stream_pages(conn, prepared, values, opts)
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -143,6 +143,9 @@ defmodule Cassandrax.Connection do
   def execute(%Cassandrax.Keyspace.Batch{conn: conn, xandra_batch: xandra_batch}, opts),
     do: Xandra.execute(conn, xandra_batch, opts)
 
+  def stream_pages(conn, %Xandra.Prepared{} = prepared, values, opts),
+    do: Xandra.Cluster.stream_pages!(conn, prepared, values, opts)
+
   defp quote_name(atom) when is_atom(atom), do: quote_name(Atom.to_string(atom))
   defp quote_name(string) when is_binary(string), do: [?", string, ?"]
 

--- a/lib/cassandrax/keyspace.ex
+++ b/lib/cassandrax/keyspace.ex
@@ -100,6 +100,9 @@ defmodule Cassandrax.Keyspace do
       def all(queryable, opts \\ []),
         do: Cassandrax.Keyspace.Queryable.all(__MODULE__, queryable, opts)
 
+      def stream(queryable, opts \\ []),
+        do: Cassandrax.Keyspace.Queryable.stream(__MODULE__, queryable, opts)
+
       def get(queryable, primary_key, opts \\ []) do
         Cassandrax.Keyspace.Queryable.get(__MODULE__, queryable, primary_key, opts)
       end
@@ -271,6 +274,20 @@ defmodule Cassandrax.Keyspace do
               Cassandrax.Schema.t()
             ]
 
+  @doc """
+  Streams all entries from the data store that matches the given query.
+
+  May raise Xandra.Error if query validation fails.
+
+  ## Example
+  ```
+  query = where(User, id: 1)
+  MyKeyspace.stream(query)
+  ```
+  """
+  @callback stream(queryable :: Cassandrax.Queryable.t(), opts :: Keyword.t()) :: [
+              Cassandrax.Schema.t()
+            ]
   @doc """
 
   ## Example

--- a/test/cassandrax/keyspace_test.exs
+++ b/test/cassandrax/keyspace_test.exs
@@ -332,6 +332,30 @@ defmodule Cassandrax.KeyspaceTest do
     end
   end
 
+  describe "stream" do
+    setup do
+      [
+        first: fixture(TestData, id: "0", timestamp: "00:00", data: "0"),
+        second:
+          fixture(TestData,
+            id: "1",
+            timestamp: "01:00",
+            data: "1",
+            svalue: MapSet.new(["one", "another one"])
+          )
+      ]
+    end
+
+    test "stream", %{first: first, second: second} do
+      streamed_records =
+        TestData
+        |> TestKeyspace.stream(page_size: 1)
+        |> Enum.to_list()
+
+      assert list_sets_equal?(streamed_records, [first, second])
+    end
+  end
+
   describe "one" do
     test "fails on table with no entries" do
       assert TestKeyspace.one(TestData) == nil


### PR DESCRIPTION
Streams are much more convenient when dealing with large amounts of data. I've implemented a wrapper on top of [Xandra.stream_pages!/4](https://github.com/lexhide/xandra/blob/67e9cf14a60c09bd69aa51fb1e73d85e54969e8d/lib/xandra.ex#L568).

Please let me know if this could be useful for the project or if support has already been planned in a different way. Feel free to close if this is not wanted.