### PR TITLE
Explicit order_by support

### DIFF
--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -73,6 +73,10 @@ defmodule Cassandrax.Connection do
     [" ORDER BY ", intersperse_map(order_bys, ", ", &extract_order(&1))]
   end
 
+  defp extract_order({:asc, field}), do: [quote_name(field) | " ASC"]
+  defp extract_order({:desc, field}), do: [quote_name(field) | " DESC"]
+  defp extract_order(field), do: quote_name(field)
+
   defp per_partition_limit(%{per_partition_limit: nil}), do: {[], []}
 
   defp per_partition_limit(%{per_partition_limit: per_partition_limit}),
@@ -153,8 +157,4 @@ defmodule Cassandrax.Connection do
 
   defp do_intersperse_map([element | rest], separator, mapper),
     do: [mapper.(element), separator | do_intersperse_map(rest, separator, mapper)]
-
-  defp extract_order({:asc, field}), do: [quote_name(field) | " ASC"]
-  defp extract_order({:desc, field}), do: [quote_name(field) | " DESC"]
-  defp extract_order(field), do: quote_name(field)
 end

--- a/lib/cassandrax/connection.ex
+++ b/lib/cassandrax/connection.ex
@@ -70,7 +70,7 @@ defmodule Cassandrax.Connection do
   defp order_by(%{order_bys: []}), do: []
 
   defp order_by(%{order_bys: order_bys}) when is_list(order_bys) do
-    [" ORDER BY ", intersperse_map(order_bys, ", ", &quote_name(&1))]
+    [" ORDER BY ", intersperse_map(order_bys, ", ", &extract_order(&1))]
   end
 
   defp per_partition_limit(%{per_partition_limit: nil}), do: {[], []}
@@ -153,4 +153,8 @@ defmodule Cassandrax.Connection do
 
   defp do_intersperse_map([element | rest], separator, mapper),
     do: [mapper.(element), separator | do_intersperse_map(rest, separator, mapper)]
+
+  defp extract_order({:asc, field}), do: [quote_name(field) | " ASC"]
+  defp extract_order({:desc, field}), do: [quote_name(field) | " DESC"]
+  defp extract_order(field), do: quote_name(field)
 end

--- a/lib/cassandrax/query.ex
+++ b/lib/cassandrax/query.ex
@@ -119,6 +119,12 @@ defmodule Cassandrax.Query do
   ```
   query = User |> allow_filtering() |> where(:id == 1) |> order_by([:device_id])
   ```
+
+  You can set an explicit order.
+
+  ```
+  query = User |> allow_filtering() |> where(:id == 1) |> order_by([asc: :device_id])
+  ```
   """
   @callback order_by(queryable :: Cassandrax.Queryable.t(), order_by :: Keyword.t()) ::
               Cassandrax.Query.t()

--- a/lib/cassandrax/schema.ex
+++ b/lib/cassandrax/schema.ex
@@ -89,7 +89,9 @@ defmodule Cassandrax.Schema do
       end
 
       if @partition_key == [] do
-        raise(Cassandrax.SchemaError, message: "@primary_key cannot define an empty partition_key")
+        raise(Cassandrax.SchemaError,
+          message: "@primary_key cannot define an empty partition_key"
+        )
       end
 
       for clustering_key <- clustering_keys do

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -65,6 +65,11 @@ defmodule Cassandrax.ConnectionTest do
       assert all(queryable) =~ ~r/ORDER BY "order_id"/
     end
 
+    test "defined order by clause with explicit order" do
+      queryable = TestSchema |> order_by(desc: :order_id, asc: :field)
+      assert all(queryable) =~ ~r/ORDER BY "order_id" DESC, "field" ASC/
+    end
+
     test "defined per partition limit clause" do
       queryable = TestSchema |> per_partition_limit(25)
       assert all(queryable) =~ ~r/PER PARTITION LIMIT \?/

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -65,7 +65,7 @@ defmodule Cassandrax.ConnectionTest do
       assert all(queryable) =~ ~r/ORDER BY "order_id"/
     end
 
-    test "defined order by clause with explicit order" do
+    test "defined order by clause with an explicit order" do
       queryable = TestSchema |> order_by(desc: :order_id, asc: :field)
       assert all(queryable) =~ ~r/ORDER BY "order_id" DESC, "field" ASC/
     end

--- a/test/cassandrax/connection_test.exs
+++ b/test/cassandrax/connection_test.exs
@@ -66,8 +66,8 @@ defmodule Cassandrax.ConnectionTest do
     end
 
     test "defined order by clause with an explicit order" do
-      queryable = TestSchema |> order_by(desc: :order_id, asc: :field)
-      assert all(queryable) =~ ~r/ORDER BY "order_id" DESC, "field" ASC/
+      queryable = TestSchema |> order_by(desc: :order_id, asc: :field, desc: :id)
+      assert all(queryable) =~ ~r/ORDER BY "order_id" DESC, "field" ASC, "id" DESC/
     end
 
     test "defined per partition limit clause" do

--- a/test/cassandrax/keyspace_test.exs
+++ b/test/cassandrax/keyspace_test.exs
@@ -598,6 +598,18 @@ defmodule Cassandrax.KeyspaceTest do
       assert [^first, ^second] = TestKeyspace.all(query)
     end
 
+    test "order by asc", %{first: first, second: second} do
+      query = TestData |> allow_filtering() |> where(id: "0") |> order_by(asc: :timestamp)
+
+      assert [^first, ^second] = TestKeyspace.all(query)
+    end
+
+    test "order by desc", %{first: first, second: second} do
+      query = TestData |> allow_filtering() |> where(id: "0") |> order_by(desc: :timestamp)
+
+      assert [^second, ^first] = TestKeyspace.all(query)
+    end
+
     test "distinct" do
       query = TestData |> allow_filtering() |> distinct([:id])
       assert [%TestData{id: "0"}, %TestData{id: "1"}] = TestKeyspace.all(query)


### PR DESCRIPTION
Adding the support for defining the explicit order for order_by

Keeping the same definition style with Ecto.
https://hexdocs.pm/ecto/Ecto.Query.html#order_by/3-keywords-examples 

### Example

order_by(q, [desc: :elapsed_time])